### PR TITLE
Reintroduce QR panel and fix viewport fit

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,21 +93,26 @@
           <label class="btn filelabel">Imagen
             <input id="fileImg" type="file" accept="image/*" />
           </label>
-          <button id="btnQRWA" class="btn">QR WhatsApp</button>
-          <button id="btnQRURL" class="btn">QR URL</button>
         </div>
       </details>
 
-      <details><summary>Navegación</summary>
+      <details><summary>Códigos QR</summary>
         <div class="stack">
           <div class="row">
-            <button id="btnHand" class="btn">✋ Mano</button>
-            <small class="muted">Arrastrá el lienzo. También funciona con <b>barra espaciadora</b> o con <b>dos dedos</b>.</small>
+            <label class="lbl small" for="waPhone">WhatsApp</label>
+            <input id="waPhone" type="tel" class="field" placeholder="Ej: 5491122334455" />
           </div>
           <div class="row">
-            <button id="btnZoomFit" class="btn">Ajustar</button>
-            <button id="btnZoomReset" class="btn">1:1</button>
+            <label class="lbl small" for="waMsg">Mensaje</label>
+            <input id="waMsg" type="text" class="field" placeholder="Opcional" />
           </div>
+          <button id="btnQRWA" class="btn">Generar QR WhatsApp</button>
+          <hr class="divider" />
+          <div class="row">
+            <label class="lbl small" for="inURL">URL</label>
+            <input id="inURL" type="url" class="field" placeholder="https://" />
+          </div>
+          <button id="btnQRURL" class="btn">Generar QR URL</button>
         </div>
       </details>
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -113,11 +113,13 @@ function updateZoomLabel(){ document.getElementById('zoomLabel').textContent = M
 
 export function fitToViewport(){
   const outer = document.getElementById('viewport'); if(!outer||!canvas) return;
-  const M = 24; const W = outer.clientWidth - M, H = outer.clientHeight - M;
+  const W = outer.clientWidth, H = outer.clientHeight;
   const w = canvas.getWidth(), h = canvas.getHeight();
   const s = Math.max(MIN_Z, Math.min(MAX_Z, Math.min(W/w, H/h)));
   const tx = (W - w*s)/2, ty = (H - h*s)/2;
-  canvas.setViewportTransform([s,0,0,s,tx,ty]); updateZoomLabel();
+  canvas.setViewportTransform([s,0,0,s,tx,ty]);
+  updateZoomLabel();
+  canvas.requestRenderAll();
 }
 
 export function zoomTo(newZ, centerPoint, recenter=false){

--- a/src/ui.js
+++ b/src/ui.js
@@ -89,7 +89,7 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btnZoomOut').addEventListener('click', ()=> zoomTo(canvas.getZoom()/1.1));
   document.getElementById('btnZoomReset').addEventListener('click', ()=> zoomTo(1, null, true));
   document.getElementById('btnZoomFit').addEventListener('click', ()=> { setAutoCenter(true); fitToViewport(); });
-  document.getElementById('btnHand').addEventListener('click', toggleHand);
+    document.getElementById('btnHandHUD').addEventListener('click', toggleHand);
 
   // Resize/Orientation
   window.addEventListener('resize', ()=> { if(getAutoCenter()) fitToViewport(); });


### PR DESCRIPTION
## Summary
- Restore a dedicated accordion panel for generating WhatsApp and URL QR codes and remove QR buttons from the Insert section
- Remove the navigation panel and wire the central hand button to toggle pan mode
- Correct the "Ajustar" behavior by recalculating viewport fitting

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b316d02fa8832a941b10ae372734cd