### PR TITLE
Implement feather mask clipPath and cleanup

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -265,10 +265,10 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
   const scale = ((obj.scaleX || 1) + (obj.scaleY || 1)) / 2;
   const f = feather / scale;
 
-  let clip;
+  let clipPath;
   if(shape === 'circle'){
     const radius = Math.max(w, h) / 2;
-    clip = new fabric.Circle({
+    clipPath = new fabric.Circle({
       radius,
       originX: 'center',
       originY: 'center',
@@ -277,14 +277,7 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
       fill: new fabric.Gradient({
         type: 'radial',
         gradientUnits: 'pixels',
-        coords: {
-          x1: 0,
-          y1: 0,
-          r1: Math.max(radius - f, 0),
-          x2: 0,
-          y2: 0,
-          r2: radius
-        },
+        coords: { x1:0, y1:0, r1:Math.max(radius - f, 0), x2:0, y2:0, r2:radius },
         colorStops: [
           { offset: 0, color: 'rgba(0,0,0,1)' },
           { offset: 1, color: 'rgba(0,0,0,0)' }
@@ -293,7 +286,7 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
     });
   } else {
     const maxR = Math.max(w, h) / 2;
-    clip = new fabric.Rect({
+    clipPath = new fabric.Rect({
       width: w,
       height: h,
       originX: 'center',
@@ -303,14 +296,7 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
       fill: new fabric.Gradient({
         type: 'radial',
         gradientUnits: 'pixels',
-        coords: {
-          x1: 0,
-          y1: 0,
-          r1: Math.max(maxR - f, 0),
-          x2: 0,
-          y2: 0,
-          r2: maxR
-        },
+        coords: { x1:0, y1:0, r1:Math.max(maxR - f, 0), x2:0, y2:0, r2:maxR },
         colorStops: [
           { offset: 0, color: 'rgba(0,0,0,1)' },
           { offset: 1, color: 'rgba(0,0,0,0)' }
@@ -319,13 +305,18 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
     });
   }
 
-  obj.clipPath = clip;
+  obj.clipPath = clipPath;
+  obj._featherClip = clipPath;
   canvas.requestRenderAll();
 }
 
 export function removeFeatherMaskFromActive(){
   const obj = canvas.getActiveObject();
   if(!obj || !(obj instanceof fabric.Image)) return;
+  if(obj._featherClip){
+    obj._featherClip.dispose?.();
+    delete obj._featherClip;
+  }
   obj.clipPath = null;
   canvas.requestRenderAll();
 }


### PR DESCRIPTION
## Summary
- Create radial gradient clip paths for rectangular and circular feather masks.
- Store and clean up clipPath references when applying or removing masks.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b32301ab70832a87c6ecc55e2ef657