### PR TITLE
Use clipPath gradients for feather mask

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -265,10 +265,10 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
   const scale = ((obj.scaleX || 1) + (obj.scaleY || 1)) / 2;
   const f = feather / scale;
 
-  let clip;
+  let clipPath;
   if(shape === 'circle'){
-    const radius = Math.max(w, h) / 2;
-    clip = new fabric.Circle({
+    const radius = Math.min(w, h) / 2;
+    clipPath = new fabric.Circle({
       radius,
       originX: 'center',
       originY: 'center',
@@ -277,14 +277,7 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
       fill: new fabric.Gradient({
         type: 'radial',
         gradientUnits: 'pixels',
-        coords: {
-          x1: 0,
-          y1: 0,
-          r1: Math.max(radius - f, 0),
-          x2: 0,
-          y2: 0,
-          r2: radius
-        },
+        coords: { x1: radius, y1: radius, r1: Math.max(radius - f, 0), x2: radius, y2: radius, r2: radius },
         colorStops: [
           { offset: 0, color: 'rgba(0,0,0,1)' },
           { offset: 1, color: 'rgba(0,0,0,0)' }
@@ -292,8 +285,8 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
       })
     });
   } else {
-    const maxR = Math.max(w, h) / 2;
-    clip = new fabric.Rect({
+    const r2 = Math.hypot(w/2, h/2);
+    clipPath = new fabric.Rect({
       width: w,
       height: h,
       originX: 'center',
@@ -303,14 +296,7 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
       fill: new fabric.Gradient({
         type: 'radial',
         gradientUnits: 'pixels',
-        coords: {
-          x1: 0,
-          y1: 0,
-          r1: Math.max(maxR - f, 0),
-          x2: 0,
-          y2: 0,
-          r2: maxR
-        },
+        coords: { x1: w/2, y1: h/2, r1: Math.max(r2 - f, 0), x2: w/2, y2: h/2, r2 },
         colorStops: [
           { offset: 0, color: 'rgba(0,0,0,1)' },
           { offset: 1, color: 'rgba(0,0,0,0)' }
@@ -319,13 +305,18 @@ export function applyFeatherMaskToActive(feather = 40, shape = 'rect'){
     });
   }
 
-  obj.clipPath = clip;
+  obj.clipPath = clipPath;
+  obj._featherClip = clipPath;
   canvas.requestRenderAll();
 }
 
 export function removeFeatherMaskFromActive(){
   const obj = canvas.getActiveObject();
   if(!obj || !(obj instanceof fabric.Image)) return;
+  if(obj._featherClip){
+    obj._featherClip.dispose?.();
+    delete obj._featherClip;
+  }
   obj.clipPath = null;
   canvas.requestRenderAll();
 }


### PR DESCRIPTION
## Summary
- Center radial-gradient clipPaths so feathered edges fade evenly for circular and rectangular masks
- Keep clipPath reference on images and clear it when removing the feather effect
- Confirm UI buttons still invoke feather mask apply/remove helpers with chosen strength and shape

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/minicanva-crop-modal/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b32301ab70832a87c6ecc55e2ef657